### PR TITLE
fixed index error in knn classify function

### DIFF
--- a/knn/knn.py
+++ b/knn/knn.py
@@ -75,7 +75,7 @@ class Knearest:
         # Finish this function to find the k closest points, query the
         # majority function, and return the value.
 
-        return self.majority(list(random.randint(0, len(self._y)) \
+        return self.majority(list(random.randrange(len(self._y)) \
                                   for x in xrange(self._k)))
 
     def confusion_matrix(self, test_x, test_y):


### PR DESCRIPTION
The dummy code for the KNN classify function can cause an IndexError. `random.randint(0, len(self._y))` can return the value `len(self._y)`, which is out of range. Instead, using `random.randrange(len(self._y))` does what is expected.
