### PR TITLE
Fix lda unit test

### DIFF
--- a/vb/test.py
+++ b/vb/test.py
@@ -43,19 +43,16 @@ class TestVB(unittest.TestCase):
     def test_m(self):
         vb = VariationalBayes()
         vb.init([], "stuck", 3)
-        # vb.m_step(self.init_beta)
-
-        # self.assertAlmostEqual(self.init_beta[2][3], vb._beta[2][3])
 
         topic_count = array([[5., 4., 3., 2., 1.],
                              [0., 2., 2., 4., 1.],
                              [1., 1., 1., 1., 1.]])
 
-        vb.m_step(topic_count)
-        self.assertAlmostEqual(vb._beta[2][3], .2)
-        self.assertAlmostEqual(vb._beta[0][0], .33333333)
-        self.assertAlmostEqual(vb._beta[1][4], .11111111)
-        self.assertAlmostEqual(vb._beta[0][3], .13333333)
+        new_beta = vb.m_step(topic_count)
+        self.assertAlmostEqual(new_beta[2][3], .2)
+        self.assertAlmostEqual(new_beta[0][0], .33333333)
+        self.assertAlmostEqual(new_beta[1][4], .11111111)
+        self.assertAlmostEqual(new_beta[0][3], .13333333)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The test `test_m` attempts to test the m_step of the algorithm is working properly. However, the unit test
goes about checking that `vb._beta` is `almostEqual` to certain values, instead of checking that the return value of `m_step` conforms to these calls. Since the call to `m_step` does not actually update `vb._beta`, it does not make sense to test that variable. This commit fixes the test by instead testing what
is returned from `m_step`.
